### PR TITLE
Fix x64 build, add linux define and missing X64_ABS_SIZE

### DIFF
--- a/extension/AMBuildScript
+++ b/extension/AMBuildScript
@@ -261,7 +261,7 @@ class ExtensionConfig(object):
     cxx.cflags += ['/Oy-']
 
   def configure_linux(self, cxx):
-    cxx.defines += ['_LINUX', 'POSIX']
+    cxx.defines += ['LINUX', '_LINUX', 'POSIX']
     cxx.linkflags += ['-Wl,--exclude-libs,ALL', '/usr/local/lib/libopus.a']
     if cxx.vendor == 'gcc':
       cxx.linkflags += ['-static-libgcc']

--- a/extension/CDetour/detours.cpp
+++ b/extension/CDetour/detours.cpp
@@ -35,6 +35,11 @@
 ISourcePawnEngine *CDetourManager::spengine = NULL;
 IGameConfig *CDetourManager::gameconf = NULL;
 
+#if defined(_WIN64) || defined(__x86_64__)
+// push imm32 + mov [rsp+4], imm32 + ret
+#define X64_ABS_SIZE 14
+#endif
+
 // Push 64-bit value onto the stack using two instructions.
 //
 // Pushing 0xF00DF00DF00DF00D:


### PR DESCRIPTION
- add LINUX define for Linux/x64 platform macro resolution\n- add missing X64_ABS_SIZE used by x64 detour restore path